### PR TITLE
Fix paths for python install

### DIFF
--- a/py-forust/pyproject.toml
+++ b/py-forust/pyproject.toml
@@ -5,12 +5,12 @@ build-backend = "maturin"
 [project]
 name = "forust"
 description = "A lightweight gradient boosting implementation in Rust."
-license = {file = "LICENSE"}
+license = {file = "../LICENSE"}
 keywords = ["rust", "forust", "machine learning", "xgboost", "tree model", "decision tree"]
 authors = [
   {name = "James Inlow"}
 ]
-readme = "README.md"
+readme = "../README.md"
 dependencies = ["numpy>=1.21", "pandas>=1.3"]
 requires-python = ">=3.7"
 classifiers = [


### PR DESCRIPTION
`pip install forust` (also for main branch) was throwing an error due to the paths for readme and license not being correct. This fixes that.
