### PR TITLE
Add runnable `titanic` example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rand = "0.8"
 
 [dev-dependencies]
 criterion = "0.4"
+polars = "0.28"
+reqwest = { version = "0.11", features = ["blocking"] }
 
 [[bench]]
 name = "forust_benchmarks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ serde = { version = "1.0", features = ["derive"] }
 rand = "0.8"
 
 [dev-dependencies]
-criterion = "0.4"
-polars = "0.28"
+criterion = "0.5"
+polars = "0.29"
 reqwest = { version = "0.11", features = ["blocking"] }
 
 [[bench]]

--- a/examples/titanic.rs
+++ b/examples/titanic.rs
@@ -1,0 +1,58 @@
+//! An example using the `titanic` dataset
+
+use forust_ml::{GradientBooster, Matrix};
+use polars::prelude::*;
+use reqwest::blocking::Client;
+use std::error::Error;
+use std::io::Cursor;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let data = Vec::from_iter(
+        Client::new()
+            .get("https://raw.githubusercontent.com/mwaskom/seaborn-data/master/titanic.csv")
+            .send()?
+            .text()?
+            .bytes(),
+    );
+
+    let df = CsvReader::new(Cursor::new(data))
+        .has_header(true)
+        .finish()?
+        .select(["survived", "pclass", "age", "sibsp", "parch", "fare"])?;
+
+    // Get data in column major format...
+    let id_vars: Vec<&str> = Vec::new();
+    let mdf = df.melt(id_vars, ["pclass", "age", "sibsp", "parch", "fare"])?;
+
+    let data = Vec::from_iter(
+        mdf.select_at_idx(1)
+            .expect("Invalid column")
+            .f64()?
+            .into_iter()
+            .map(|v| v.unwrap_or(f64::NAN)),
+    );
+    let y = Vec::from_iter(
+        df.column("survived")?
+            .cast(&DataType::Float64)?
+            .f64()?
+            .into_iter()
+            .map(|v| v.unwrap_or(f64::NAN)),
+    );
+
+    // Create Matrix from ndarray.
+    let matrix = Matrix::new(&data, y.len(), 5);
+
+    // Create booster.
+    // To provide parameters generate a default booster, and then use
+    // the relevant `set_` methods for any parameters you would like to
+    // adjust.
+    let mut model = GradientBooster::default().set_learning_rate(0.3);
+    model.fit_unweighted(&matrix, &y, None)?;
+
+    println!(
+        "Model prediction: {:?} ...",
+        &model.predict(&matrix, true)[0..10]
+    );
+
+    Ok(())
+}

--- a/py-forust/Cargo.toml
+++ b/py-forust/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.17", features = ["extension-module"] }
-forust-ml = { version="0.2.11", path="../" }
+forust-ml = { version = "0.2.11", path = "../" }
 numpy = "0.17.2"
 ndarray = "0.15.1"

--- a/rs-example.md
+++ b/rs-example.md
@@ -4,7 +4,7 @@ To run this example, add the following code to your `Cargo.toml` file.
 ```toml
 [dependencies]
 forust-ml = "0.2.11"
-polars = "0.24"
+polars = "0.28"
 reqwest = { version = "0.11", features = ["blocking"] }
 ```
 

--- a/rs-example.md
+++ b/rs-example.md
@@ -51,12 +51,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Create Matrix from ndarray.
     let matrix = Matrix::new(&data, y.len(), 5);
 
-    // Create booster
+    // Create booster.
     // To provide parameters generate a default booster, and then use
-    // the relevant "set_" methods for any parameters you would like to
+    // the relevant `set_` methods for any parameters you would like to
     // adjust.
     let mut model = GradientBooster::default().set_learning_rate(0.3);
-    model.fit_unweighted(&matrix, &y)?;
+    model.fit_unweighted(&matrix, &y, None)?;
 
     // Predict output.
     println!("{:?} ...", &model.predict(&matrix, true)[0..10]);


### PR DESCRIPTION
### Changes include:
- Adds runnable (`cargo run --example titanic`) example
- Fix `rs-example.md` to include the third parameter to `fit-unweighted`
- Update dependencies where possible
- Format `toml` files with `taplo fmt` for consistency