### PR TITLE
Adding bounds to missing branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forust-ml"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 authors = ["James Inlow <james.d.inlow@gmail.com>"]
 homepage = "https://github.com/jinlow/forust"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install forust
 
 To use in a rust project add the following to your Cargo.toml file.
 ```toml
-forust-ml = "0.2.12"
+forust-ml = "0.2.13"
 ```
 
 ## Usage

--- a/py-forust/Cargo.toml
+++ b/py-forust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-forust"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.17", features = ["extension-module"] }
-forust-ml = { version = "0.2.12", path = "../" }
+forust-ml = { version = "0.2.13", path = "../" }
 numpy = "0.17.2"
 ndarray = "0.15.1"

--- a/rs-example.md
+++ b/rs-example.md
@@ -3,7 +3,7 @@
 To run this example, add the following code to your `Cargo.toml` file.
 ```toml
 [dependencies]
-forust-ml = "0.2.12"
+forust-ml = "0.2.13"
 polars = "0.28"
 reqwest = { version = "0.11", features = ["blocking"] }
 ```

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -329,7 +329,7 @@ impl Splitter for MissingBranchSplitter {
             cover: missing_hessian,
             weight: missing_weight,
             // Constrain to the same bounds as the parent.
-            // This will ensure that no splits further down in the missing only
+            // This will ensure that splits further down in the missing only
             // branch are monotonic.
             bounds: (lower_bound, upper_bound),
         };

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -328,7 +328,9 @@ impl Splitter for MissingBranchSplitter {
             gain: missing_gain,
             cover: missing_hessian,
             weight: missing_weight,
-            bounds: (f32::NEG_INFINITY, f32::INFINITY),
+            // Constrain to the same level as the parent weight.
+            // The more I think about this the more it makes sense.
+            bounds: (lower_bound, upper_bound),
         };
         let missing_node = // Check Missing direction
         if ((missing_gradient != 0.0) || (missing_hessian != 0.0)) && self.allow_missing_splits {

--- a/src/splitter.rs
+++ b/src/splitter.rs
@@ -328,8 +328,9 @@ impl Splitter for MissingBranchSplitter {
             gain: missing_gain,
             cover: missing_hessian,
             weight: missing_weight,
-            // Constrain to the same level as the parent weight.
-            // The more I think about this the more it makes sense.
+            // Constrain to the same bounds as the parent.
+            // This will ensure that no splits further down in the missing only
+            // branch are monotonic.
             bounds: (lower_bound, upper_bound),
         };
         let missing_node = // Check Missing direction


### PR DESCRIPTION
I think we need to do this... Right now, when a missing branch is created, we assign no upper and lower bounds...
Consider this example, where the tuple is the (feature name, weight value), the center line is the missing branch. Assume these two features have positive monotone constraints.
```
                (B, 0.)
               /   |    \
             L     M     R
            /      |      \
         (C, -1)   0.      1
       /    |   \
      L     M    R
     /      |     \ 
   -2   (B, -1)   -0.5
        /  |  \
       L   M   R
      /    |    \
     -3   -1    10
```
Let's say this first split on feature B are records greater than 10, or less than 10. All values greater than 10 go right less than go left. We see under the missing split, for C, that these values less than 10 could end up with a weight value higher than those greater than 10 because the constraint isn't carried down from the parent. With this fix, this would never happen, The new B split would never go above -0.5, because it would use the bounds of the parent.
I have ran several tests, and never observe this happening in a model, but this seems like a good thing to add to exclude any possible edge cases. Testing on a large real dataset it makes little to no impact on performance.

